### PR TITLE
i18n(bg): KPI footer reads 'При [Кабинет]', not 'Под [Кабинет]'

### DIFF
--- a/src/locales/bg/translation.json
+++ b/src/locales/bg/translation.json
@@ -2463,7 +2463,7 @@
   "kpi_verdict_good": "по-добре от ЕС",
   "kpi_verdict_neutral": "близо до средното",
   "kpi_verdict_concern": "под средното",
-  "kpi_under_cabinet": "Под {{name}}: {{start}} → {{end}} ({{delta}})",
+  "kpi_under_cabinet": "При {{name}}: {{start}} → {{end}} ({{delta}})",
   "gov_chart_tenure_avg_label": "Средно за мандата",
   "indicators_hero_chart_expand": "Покажи общата графика",
   "indicators_hero_chart_collapse": "Скрий общата графика",


### PR DESCRIPTION
## Summary
- 'При Борисов' is the natural Bulgarian phrasing for the tenure-bounded delta context on the indicators tiles (= 'during Borisov's tenure' / 'in the Borisov era')
- 'Под Борисов' read as either subordination or a vague 'beneath' — both wrong
- English 'Under [Cabinet]' stays unchanged

## Test plan
- [ ] Visit /indicators?cabinet=borisov-3 in Bulgarian; tile footers should say 'При Борисов: X → Y (...)' instead of 'Под Борисов: ...'
- [ ] EN locale unaffected