### PR TITLE
fix: decouple cabinet anchor from election snapshots

### DIFF
--- a/src/data/macro/cabinetAnchorContext.tsx
+++ b/src/data/macro/cabinetAnchorContext.tsx
@@ -1,14 +1,17 @@
-// Global cabinet anchor — a single selected cabinet whose tenure-end snapshot
-// drives every quarterly/annual macro selector across the governments +
-// indicators route group. Sourced from `?cabinet=<id>` so the choice is
-// shareable, lifted from /indicators/compare to a route-group provider so the
-// same anchor flows through /governments, /indicators (and its four domain
-// pages), /governments/:slug, and back into /compare.
+// Global cabinet anchor — a single selected cabinet, URL-encoded as
+// `?cabinet=<id>` and surfaced via context across the governments +
+// indicators route group. Used by the header pill, the per-tile "При
+// [Cabinet]" footer, the cabinet-detail page, and (opt-in) the /compare
+// snapshot panels.
 //
-// Screens that don't mount the provider retain election-driven behavior via
-// the existing useElectionAsOf / useElectionYear fallthrough — both hooks
-// consult useCompareAnchorOverride() first, which returns null outside the
-// provider.
+// The anchor is **additive** for most consumers: KpiTile headlines,
+// PeerSnapshotTable on /economy / /fiscal, etc. read the *election*-driven
+// snapshot via useElectionAsOf, so the period label on each tile always
+// matches the election the user picked in the header. Components that
+// genuinely want to re-anchor (the /compare WGI radar, COFOG multiples,
+// inequality panel, spend-outcome scatters, the /compare PeerSnapshotTable)
+// opt in explicitly via useCompareSnapshotAsOf / useCompareSnapshotYear,
+// which fall back from cabinet anchor → election.
 
 import {
   createContext,
@@ -113,13 +116,28 @@ export const useSetCabinetAnchor = (): ((id: string | null) => void) => {
   return setter ?? (() => undefined);
 };
 
-/** Narrowed view used by useElectionAsOf / useElectionYear. Kept as its own
- *  hook so the snapshot-reading layer doesn't reach into the cabinet record. */
-export const useCompareAnchorOverride = (): {
-  asOf: AsOf | null;
-  year: number;
-} | null => {
+/** Three-state return:
+ *   - `undefined` → no anchor set; caller should fall back to election asOf
+ *   - `null`      → anchor IS set but the cabinet is incumbent (= "use the
+ *                   literal latest available point", a meaningful asOf
+ *                   value that pickAtOrBefore interprets specifically)
+ *   - `{year, quarter}` → anchored to cabinet's tenure-end quarter
+ *
+ *  The three-state semantic lets useCompareSnapshotAsOf distinguish "no
+ *  override" from "override that means latest data" without conflating
+ *  them.
+ */
+export type CabinetAnchorAsOf = AsOf | null | undefined;
+
+export const useCabinetAnchorAsOf = (): CabinetAnchorAsOf => {
   const anchor = useContext(CabinetAnchorContext);
-  if (!anchor) return null;
-  return { asOf: anchor.asOf, year: anchor.year };
+  if (!anchor) return undefined;
+  return anchor.asOf;
+};
+
+/** Annual anchor — cabinet's tenure-end year when an anchor is set, else
+ *  `null` (caller falls back to election year). */
+export const useCabinetAnchorYear = (): number | null => {
+  const anchor = useContext(CabinetAnchorContext);
+  return anchor?.year ?? null;
 };

--- a/src/data/macro/useElectionAsOf.tsx
+++ b/src/data/macro/useElectionAsOf.tsx
@@ -6,22 +6,28 @@
 // Sibling to `screens/components/euCompare/useElectionYear.ts` — that one is
 // year-only (sufficient for annual COFOG / WGI / SILC series); this one keeps
 // quarter resolution because the KPI series are mostly quarterly.
+//
+// Pure election-driven on purpose. Earlier versions of this hook also
+// consulted the cabinet anchor (useCompareAnchorOverride) so /compare panels
+// would re-anchor to the cabinet's tenure end. That coupling leaked the
+// override into every other consumer (KpiTile headlines, PeerSnapshotTable
+// on /economy and /fiscal), making the tile period label disagree with the
+// selected election. Now the cabinet anchor is additive only — readers that
+// genuinely want the anchored snapshot opt in via useCabinetAnchorAsOf().
 
 import { useMemo } from "react";
 import { useElectionContext } from "@/data/ElectionContext";
+import {
+  useCabinetAnchorAsOf,
+  type CabinetAnchorAsOf,
+} from "./cabinetAnchorContext";
 import type { AsOf } from "./kpiSelectors";
-import { useCompareAnchorOverride } from "./cabinetAnchorContext";
 
 export type ElectionAsOf = AsOf;
 
 export const useElectionAsOf = (): ElectionAsOf | null => {
   const { selected } = useElectionContext();
-  // CabinetAnchorProvider (mounted on /governments and /indicators routes)
-  // re-anchors every panel to the URL-selected cabinet's tenure. Pages
-  // outside that provider get null → election behavior preserved.
-  const override = useCompareAnchorOverride();
   return useMemo(() => {
-    if (override) return override.asOf;
     if (!selected) return null;
     const m = /^(\d{4})_(\d{2})_(\d{2})$/.exec(selected);
     if (!m) return null;
@@ -29,5 +35,23 @@ export const useElectionAsOf = (): ElectionAsOf | null => {
     const month0 = Number(m[2]) - 1;
     const quarter = (Math.floor(month0 / 3) + 1) as 1 | 2 | 3 | 4;
     return { year, quarter };
-  }, [selected, override]);
+  }, [selected]);
+};
+
+/** Compare-screen quarterly snapshot anchor. Returns the cabinet's
+ *  tenure-end asOf when an anchor is set, else the election asOf. Use on
+ *  /compare panels that should re-anchor to the picked cabinet's tenure end
+ *  (PeerSnapshotTable etc.). Other consumers — KpiTile headlines, snapshot
+ *  panels on /economy / /fiscal — keep using useElectionAsOf so their
+ *  reading matches the election the user picked in the header. */
+export const useCompareSnapshotAsOf = (): AsOf | null => {
+  const anchorAsOf: CabinetAnchorAsOf = useCabinetAnchorAsOf();
+  const electionAsOf = useElectionAsOf();
+  // The anchor explicitly encodes "incumbent" as asOf=null + year=current,
+  // which means "use the latest available point". Preserve that semantic —
+  // returning null from this hook causes pickAtOrBefore to short-circuit to
+  // the literal tail of the series, which is what we want for the still-in-
+  // office case.
+  if (anchorAsOf !== undefined) return anchorAsOf;
+  return electionAsOf;
 };

--- a/src/screens/components/euCompare/EuCompareCofogMultiples.tsx
+++ b/src/screens/components/euCompare/EuCompareCofogMultiples.tsx
@@ -27,7 +27,7 @@ import {
   GEO_SHORT_EN,
   usePeerSelection,
 } from "./usePeerSelection";
-import { useElectionYear } from "./useElectionYear";
+import { useCompareSnapshotYear } from "./useElectionYear";
 import { COFOG_FUNCTION_COLOR, COFOG_STACK_ORDER } from "./cofogPalette";
 
 type FunctionCode = Exclude<CofogCode, "TOTAL">;
@@ -47,7 +47,7 @@ export const EuCompareCofogMultiples: FC = () => {
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { data: cofog } = useCofog();
   const { geos: allGeos } = usePeerSelection();
-  const electionYear = useElectionYear();
+  const electionYear = useCompareSnapshotYear();
   const shortLabel = lang === "bg" ? GEO_SHORT_BG : GEO_SHORT_EN;
   const [hoveredGeo, setHoveredGeo] = useState<PeerGeo | null>(null);
 

--- a/src/screens/components/euCompare/EuCompareInequalityPanel.tsx
+++ b/src/screens/components/euCompare/EuCompareInequalityPanel.tsx
@@ -22,7 +22,7 @@ import {
   GEO_SHORT_EN,
   usePeerSelection,
 } from "./usePeerSelection";
-import { pickByYear, useElectionYear } from "./useElectionYear";
+import { pickByYear, useCompareSnapshotYear } from "./useElectionYear";
 
 type Metric = {
   key: string; // matches indicatorsAnnual key in macro_peers.json
@@ -153,7 +153,7 @@ export const EuCompareInequalityPanel: FC = () => {
   const { i18n } = useTranslation();
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { geos } = usePeerSelection();
-  const electionYear = useElectionYear();
+  const electionYear = useCompareSnapshotYear();
   const geoLabel = lang === "bg" ? GEO_SHORT_BG : GEO_SHORT_EN;
 
   return (

--- a/src/screens/components/euCompare/EuCompareSpendOutcomeScatters.tsx
+++ b/src/screens/components/euCompare/EuCompareSpendOutcomeScatters.tsx
@@ -38,7 +38,7 @@ import {
   GEO_SHORT_EN,
   usePeerSelection,
 } from "./usePeerSelection";
-import { pickByYear, useElectionYear } from "./useElectionYear";
+import { pickByYear, useCompareSnapshotYear } from "./useElectionYear";
 
 type FunctionCode = Exclude<CofogCode, "TOTAL">;
 
@@ -185,7 +185,7 @@ const MiniScatter: FC<{
   const { t, i18n } = useTranslation();
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { geos } = usePeerSelection();
-  const electionYear = useElectionYear();
+  const electionYear = useCompareSnapshotYear();
   const shortLabel = lang === "bg" ? GEO_SHORT_BG : GEO_SHORT_EN;
   const { points, euX, euY } = useScatterData(
     spendCode,

--- a/src/screens/components/euCompare/EuCompareWgiRadar.tsx
+++ b/src/screens/components/euCompare/EuCompareWgiRadar.tsx
@@ -32,7 +32,7 @@ import {
   GEO_COLOR,
   usePeerSelection,
 } from "./usePeerSelection";
-import { pickByYear, useElectionYear } from "./useElectionYear";
+import { pickByYear, useCompareSnapshotYear } from "./useElectionYear";
 
 // Short, localized labels for the six axes. Full names live in the
 // explanatory copy below the chart.
@@ -107,7 +107,7 @@ export const EuCompareWgiRadar: FC = () => {
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { data: peers } = useMacroPeers();
   const { geos } = usePeerSelection();
-  const electionYear = useElectionYear();
+  const electionYear = useCompareSnapshotYear();
   const wgi = peers?.wgi;
   const shortLabel = lang === "bg" ? GEO_SHORT_BG : GEO_SHORT_EN;
 

--- a/src/screens/components/euCompare/EuCompareWgiSmallMultiples.tsx
+++ b/src/screens/components/euCompare/EuCompareWgiSmallMultiples.tsx
@@ -35,7 +35,7 @@ import {
   GEO_COLOR,
   usePeerSelection,
 } from "./usePeerSelection";
-import { pickByYear, useElectionYear } from "./useElectionYear";
+import { pickByYear, useCompareSnapshotYear } from "./useElectionYear";
 
 // Per-panel tooltip — shows the three series in scope (BG, the assigned peer,
 // EU27) for whichever axis the cursor is over, sorted descending so the
@@ -189,7 +189,7 @@ export const EuCompareWgiSmallMultiples: FC = () => {
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { data: peers } = useMacroPeers();
   const { geos } = usePeerSelection();
-  const electionYear = useElectionYear();
+  const electionYear = useCompareSnapshotYear();
   const wgi = peers?.wgi;
   const shortLabel = lang === "bg" ? GEO_SHORT_BG : GEO_SHORT_EN;
   // "small" (default) — 2×3 grid of bilateral radars

--- a/src/screens/components/euCompare/useElectionYear.ts
+++ b/src/screens/components/euCompare/useElectionYear.ts
@@ -3,21 +3,34 @@
 // data point from every multi-year series — WGI, COFOG composition, SILC,
 // life expectancy — so the panels render as of the election cycle the user
 // is looking at, not the latest available data.
+//
+// Pure election-driven. The /compare-specific panels that should re-anchor
+// when the user picks a cabinet from the strip use `useCompareSnapshotYear`
+// below — it returns the cabinet anchor year when set, else falls back to
+// the election year. Keeps the cabinet anchor scoped to the panels that
+// genuinely want it instead of leaking through useElectionYear into every
+// other consumer (KpiTile, PeerSnapshotTable on /economy / /fiscal).
 
 import { useMemo } from "react";
 import { useElectionContext } from "@/data/ElectionContext";
-import { useCompareAnchorOverride } from "@/data/macro/cabinetAnchorContext";
+import { useCabinetAnchorYear } from "@/data/macro/cabinetAnchorContext";
 
 export const useElectionYear = (): number => {
   const { selected } = useElectionContext();
-  // See cabinetAnchorContext for why this falls through to election when
-  // no provider is mounted.
-  const override = useCompareAnchorOverride();
   return useMemo(() => {
-    if (override) return override.year;
     const m = /^(\d{4})/.exec(selected ?? "");
     return m ? Number(m[1]) : new Date().getFullYear();
-  }, [selected, override]);
+  }, [selected]);
+};
+
+/** Compare-screen annual snapshot year — cabinet anchor year when set, else
+ *  election year. Use in /compare's annual panels (WGI radar, COFOG
+ *  multiples, inequality panel, spend-outcome scatters) so they re-anchor
+ *  when the user picks a cabinet from the strip. */
+export const useCompareSnapshotYear = (): number => {
+  const anchorYear = useCabinetAnchorYear();
+  const electionYear = useElectionYear();
+  return anchorYear ?? electionYear;
 };
 
 // Pick the latest point in `series` with year ≤ `targetYear`. Falls back to

--- a/src/screens/components/macro/PeerSnapshotStrip.tsx
+++ b/src/screens/components/macro/PeerSnapshotStrip.tsx
@@ -107,10 +107,13 @@ export const PeerSnapshotStrip: FC<{
   formatValue?: (value: number) => string;
   /** Optional className for the wrapping element. */
   className?: string;
-}> = ({ indicatorKey, formatValue, className }) => {
+  /** Snapshot anchor override — same semantics as PeerSnapshotTable. */
+  asOf?: ElectionAsOf | null;
+}> = ({ indicatorKey, formatValue, className, asOf: asOfOverride }) => {
   const { i18n } = useTranslation();
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
-  const asOf = useElectionAsOf();
+  const electionAsOf = useElectionAsOf();
+  const asOf = asOfOverride !== undefined ? asOfOverride : electionAsOf;
   const block = usePeerIndicator(indicatorKey);
 
   if (!block) return null;

--- a/src/screens/components/macro/PeerSnapshotTable.tsx
+++ b/src/screens/components/macro/PeerSnapshotTable.tsx
@@ -234,10 +234,16 @@ export const PeerSnapshotTable: FC<{
   /** Which geo columns to render. Defaults to BG + EU27 + four CEE peers. */
   geos?: PeerGeo[];
   className?: string;
-}> = ({ rows, formatValue, geos, className }) => {
+  /** Snapshot anchor override. Pass from useCompareSnapshotAsOf() on
+   *  /compare so the table re-anchors to the picked cabinet's tenure end.
+   *  Omit on /economy and /fiscal so the table stays election-anchored
+   *  regardless of any URL `?cabinet=` the user carried over. */
+  asOf?: ElectionAsOf | null;
+}> = ({ rows, formatValue, geos, className, asOf: asOfOverride }) => {
   const { i18n } = useTranslation();
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
-  const asOf = useElectionAsOf();
+  const electionAsOf = useElectionAsOf();
+  const asOf = asOfOverride !== undefined ? asOfOverride : electionAsOf;
   const defaultFormat = formatValue ?? ((v: number) => `${v.toFixed(1)}%`);
   const geoLabel = lang === "bg" ? GEO_LABEL_BG : GEO_LABEL_EN;
   const resolvedGeos: PeerGeo[] =

--- a/src/screens/indicators/IndicatorsCompareScreen.tsx
+++ b/src/screens/indicators/IndicatorsCompareScreen.tsx
@@ -10,14 +10,19 @@
 // (?peers=RO,GR …) so the view is shareable.
 //
 // Cabinet anchor: the CabinetStrip at the top doubles as a temporal anchor
-// for every panel. Pick a cabinet → ?cabinet=<id> goes into the URL, the
-// global CabinetAnchorProvider (mounted by the route wrapper) re-resolves
-// the anchor, and every panel re-renders as values at the end of that
-// cabinet's tenure (annual + quarterly snapshots). Default selection is
-// the cabinet in office at the chosen election — applied via URL on first
-// mount if no ?cabinet= was supplied.
+// for the snapshot panels (WGI radar, COFOG multiples, inequality panel,
+// spend-outcome scatters, peer snapshot table). Pick a cabinet → ?cabinet=
+// <id> goes into the URL, and those panels re-render as values at the end
+// of that cabinet's tenure. With no cabinet picked, the panels default to
+// the election quarter — matching the rest of /indicators so the user's
+// mental model stays consistent.
+//
+// The opt-in is explicit: each panel calls useCompareSnapshotYear or
+// receives an `asOf` prop from useCompareSnapshotAsOf. KpiTile, the domain
+// pages, and the cabinet detail screen do NOT consult the anchor for their
+// headline values — only the small "При [Cabinet]" footers do.
 
-import { FC, useEffect, useMemo } from "react";
+import { FC, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { ArrowLeft, ChevronRight } from "lucide-react";
@@ -26,7 +31,7 @@ import {
   useCabinetAnchor,
   useSetCabinetAnchor,
 } from "@/data/macro/cabinetAnchorContext";
-import { useDefaultCabinetForElection } from "@/data/macro/useDefaultCabinetForElection";
+import { useCompareSnapshotAsOf } from "@/data/macro/useElectionAsOf";
 import { useMacroPeers, type PeerGeo } from "@/data/macro/useMacroPeers";
 import { PeerSnapshotTable } from "@/screens/components/macro/PeerSnapshotTable";
 import { Title } from "@/ux/Title";
@@ -48,11 +53,11 @@ export const IndicatorsCompareScreen: FC = () => {
   const { geos } = usePeerSelection();
   const anchor = useCabinetAnchor();
   const setAnchor = useSetCabinetAnchor();
-  // Default cabinet = the one whose tenure contains the selected election
-  // date — matches /indicators landing so the two screens read consistently.
-  // When the URL already carries ?cabinet=, the provider exposes it via
-  // `anchor` and we skip the auto-default below.
-  const defaultCabinetId = useDefaultCabinetForElection();
+  // Snapshot anchor for /compare panels: cabinet's tenure-end when set,
+  // election quarter otherwise. Threaded explicitly to PeerSnapshotTable so
+  // other call sites of the table (on /economy + /fiscal) stay
+  // election-only.
+  const compareAsOf = useCompareSnapshotAsOf();
 
   const indicatorKeys = peers?.indicators ? Object.keys(peers.indicators) : [];
   const tableGeos: PeerGeo[] = geos;
@@ -61,20 +66,6 @@ export const IndicatorsCompareScreen: FC = () => {
     () => (governments ? xDomainFor(governments) : null),
     [governments],
   );
-
-  // Auto-set the URL anchor on first mount so the snapshot panels have a
-  // cabinet to render against — every panel below assumes one. Guard rails:
-  // (1) wait for governments to load, (2) skip if user already has ?cabinet=,
-  // (3) skip if defaulting somehow returned null. Runs at most once per mount
-  // because once we set the param, `anchor` becomes non-null and the effect
-  // short-circuits forever (clearing via the header pill is a deliberate
-  // user action and should stick).
-  useEffect(() => {
-    if (!governments || governments.length === 0) return;
-    if (anchor) return;
-    if (!defaultCabinetId) return;
-    setAnchor(defaultCabinetId);
-  }, [anchor, defaultCabinetId, governments, setAnchor]);
 
   const selectedCabinet = anchor?.cabinet ?? null;
 
@@ -183,6 +174,7 @@ export const IndicatorsCompareScreen: FC = () => {
           <PeerSnapshotTable
             rows={indicatorKeys.map((k) => ({ indicatorKey: k }))}
             geos={tableGeos}
+            asOf={compareAsOf}
           />
         ) : (
           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
## Problem

On /indicators with `?elections=2026_04_19&cabinet=petkov` the headline tiles showed Q3 2022 values (end of Petkov tenure) and a '3 тр. 2022' period label, even though the user picked the April 2026 election. The cabinet anchor was hijacking every quarterly/annual snapshot across the governance + indicators route group, not just the /compare panels it was originally designed for.

Root cause: `useElectionAsOf` and `useElectionYear` consulted the cabinet override unconditionally after Phase 1 lifted the provider out of /compare into the whole route group.

## Fix

- `useElectionAsOf` and `useElectionYear` are now pure election-driven (drop the override consultation)
- New explicit hooks for opt-in cabinet-anchored snapshots:
  - `useCabinetAnchorAsOf` / `useCabinetAnchorYear` in cabinetAnchorContext
  - `useCompareSnapshotAsOf` / `useCompareSnapshotYear` (anchor || election fallback)
- /compare's WGI radar, COFOG multiples, inequality panel, spend-outcome scatters now use `useCompareSnapshotYear`
- `PeerSnapshotTable` + `PeerSnapshotStrip` accept an optional `asOf` prop. /compare passes `useCompareSnapshotAsOf()`; /economy + /fiscal omit it
- Removed the auto-set-anchor effect on /compare — user picks via strip or header pill (or no pick = election quarter default)

## Behavior

| Page | Headline value | Cabinet anchor effect |
|---|---|---|
| /indicators landing tiles | Election quarter | Adds 'При [Cabinet]' footer only |
| /indicators/{economy,fiscal,governance,society} | Election quarter | No effect on snapshots |
| /governments and /governments/:slug | Election (unchanged) | No effect on chart |
| /indicators/compare | Election quarter (when no anchor) or cabinet tenure-end (when anchor set) | Drives all panels |

## Test plan
- [ ] /indicators?elections=2026_04_19&cabinet=petkov → tile period label reads '2 тр. 2026' (not '3 тр. 2022')
- [ ] 'При Петков' footer still shows correct term-start → term-end delta
- [ ] /indicators/compare with no ?cabinet → panels show election-quarter data
- [ ] /indicators/compare?cabinet=denkov → WGI radar + COFOG + inequality + scatters + peer snapshot table all show end-of-Denkov data