### PR TITLE
ux: disambiguate cabinet names with Roman numerals (Borisov I/II/III)

### DIFF
--- a/scripts/prerender/routes.ts
+++ b/scripts/prerender/routes.ts
@@ -1882,6 +1882,23 @@ type CabinetEntry = {
   endReasonEn?: string;
 };
 
+// Roman numeral disambiguation, mirrors src/data/governments/cabinetLabel.ts.
+// Keeps SEO titles + body copy consistent with what users see in-app
+// ("Кабинет Бойко Методиев Борисов III" instead of just "...Борисов").
+const PRERENDER_ROMAN: Record<number, string> = {
+  1: "I",
+  2: "II",
+  3: "III",
+  4: "IV",
+  5: "V",
+};
+const cabinetNumeral = (c: CabinetEntry, siblings: CabinetEntry[]): string => {
+  if (siblings.length <= 1) return "";
+  const idx = siblings.findIndex((s) => s.id === c.id);
+  if (idx < 0) return "";
+  return PRERENDER_ROMAN[idx + 1] ?? String(idx + 1);
+};
+
 const GOVERNMENTS_FILE = path.join(PROJECT_ROOT, "data/governments.json");
 if (fs.existsSync(GOVERNMENTS_FILE)) {
   try {
@@ -1906,6 +1923,20 @@ if (fs.existsSync(GOVERNMENTS_FILE)) {
         year: "numeric",
       });
     };
+    // Pre-group cabinets by PM surname so we can compute the Roman numeral
+    // for each. Sort by start date so the chronological order maps to the
+    // numeral correctly (Borisov-1 = I, Borisov-2 = II, etc.).
+    const lastBgToken = (s: string): string => s.split(" ").pop() ?? "";
+    const sortedAll = [...payload.governments].sort((a, b) =>
+      a.startDate.localeCompare(b.startDate),
+    );
+    const siblingsByPm = new Map<string, CabinetEntry[]>();
+    for (const c of sortedAll) {
+      const key = lastBgToken(c.pmBg);
+      const arr = siblingsByPm.get(key) ?? [];
+      arr.push(c);
+      siblingsByPm.set(key, arr);
+    }
     for (const c of payload.governments) {
       const typeBg = c.type === "caretaker" ? "служебен" : "редовен";
       const typeEn = c.type === "caretaker" ? "caretaker" : "regular";
@@ -1915,23 +1946,30 @@ if (fs.existsSync(GOVERNMENTS_FILE)) {
       const tenureEn = `${fmtDateEn(c.startDate)} – ${fmtDateEn(c.endDate)}`;
       const endBg = c.endReasonBg ?? "";
       const endEn = c.endReasonEn ?? "";
+      const numeral = cabinetNumeral(
+        c,
+        siblingsByPm.get(lastBgToken(c.pmBg)) ?? [],
+      );
+      const suffix = numeral ? ` ${numeral}` : "";
+      const pmBgLabel = `${c.pmBg}${suffix}`;
+      const pmEnLabel = `${c.pmEn}${suffix}`;
       prerenderRoutes.push(
         staticPage({
           path: `governments/${c.id}`,
-          title: `Кабинет ${c.pmBg} — макро профил | electionsbg.com`,
-          description: `Профил на мандата на ${c.pmBg} (${typeBg}, ${tenureBg}): основни макроикономически и управленски показатели, средни стойности за периода и графика.`,
-          breadcrumbName: c.pmBg,
+          title: `Кабинет ${pmBgLabel} — макро профил | electionsbg.com`,
+          description: `Профил на мандата на ${pmBgLabel} (${typeBg}, ${tenureBg}): основни макроикономически и управленски показатели, средни стойности за периода и графика.`,
+          breadcrumbName: pmBgLabel,
           bodyHtml: `
-<h1>Кабинет ${c.pmBg}</h1>
+<h1>Кабинет ${pmBgLabel}</h1>
 <p><strong>${typeBg}</strong> · ${tenureBg}${partiesBg !== "—" ? ` · ${partiesBg}` : ""}${endBg ? ` · ${endBg}` : ""}</p>
 <p>Профил на мандата с показатели в началото и края, средни стойности за периода и графика на БВП, инфлация и безработица в рамките на мандата ±1 година.</p>
 <p>Виж и <a href="${SITE_URL}/governments">всички кабинети</a> или <a href="${SITE_URL}/indicators/compare?cabinet=${encodeURIComponent(c.id)}">сравнението с ЕС</a> към края на този мандат.</p>`.trim(),
           english: {
-            title: `${c.pmEn} cabinet — macro profile | electionsbg.com`,
-            description: `Profile of ${c.pmEn}'s cabinet (${typeEn}, ${tenureEn}): headline macroeconomic and governance indicators, tenure averages and macro chart.`,
-            breadcrumbName: c.pmEn,
+            title: `${pmEnLabel} cabinet — macro profile | electionsbg.com`,
+            description: `Profile of ${pmEnLabel}'s cabinet (${typeEn}, ${tenureEn}): headline macroeconomic and governance indicators, tenure averages and macro chart.`,
+            breadcrumbName: pmEnLabel,
             bodyHtml: `
-<h1>${c.pmEn} cabinet</h1>
+<h1>${pmEnLabel} cabinet</h1>
 <p><strong>${typeEn}</strong> · ${tenureEn}${partiesEn !== "—" ? ` · ${partiesEn}` : ""}${endEn ? ` · ${endEn}` : ""}</p>
 <p>Term profile with start vs. end indicator values, time-weighted averages across the tenure, and a macro chart for GDP growth, inflation and unemployment zoomed to the term ±1 year.</p>
 <p>See also <a href="${SITE_URL}/en/governments">all cabinets</a> or <a href="${SITE_URL}/en/indicators/compare?cabinet=${encodeURIComponent(c.id)}">peer comparison</a> at the end of this term.</p>`.trim(),

--- a/src/data/governments/cabinetLabel.ts
+++ b/src/data/governments/cabinetLabel.ts
@@ -1,0 +1,77 @@
+// Display-label helpers for cabinets. When the same PM has held office
+// more than once (Borisov I/II/III, Yanev I/II, Glavchev I/II), the
+// surname alone — and even the full three-name form — is ambiguous in
+// every UI surface that doesn't also show the tenure dates. The header
+// anchor pill "СПРЯМО Борисов" was the worst offender: three distinct
+// cabinets share that string.
+//
+// Convention: append the Roman numeral in chronological order (matches
+// Bulgarian media + Wikipedia naming). Singleton PMs get no numeral.
+//
+// Disambiguation key = the BG surname (last token of pmBg). It's the
+// stable language-independent grouping signal — slugs like `borisov-3`
+// happen to encode the same info but are an implementation detail; sorting
+// by `startDate` keeps the numeral ↔ tenure mapping correct even if a
+// future cabinet gets a non-`-N` slug.
+
+import type { Government } from "./useGovernments";
+
+const ROMAN: Record<number, string> = {
+  1: "I",
+  2: "II",
+  3: "III",
+  4: "IV",
+  5: "V",
+  6: "VI",
+  7: "VII",
+  8: "VIII",
+  9: "IX",
+  10: "X",
+};
+
+const toRoman = (n: number): string => ROMAN[n] ?? String(n);
+
+const lastToken = (s: string): string => s.split(" ").pop() ?? "";
+
+/** Roman numeral for a cabinet when its PM has multiple cabinets; "" for
+ *  singletons. Exposed separately so callers can render the numeral as a
+ *  chip / badge rather than concatenating into a name string. */
+export const cabinetOrdinalNumeral = (
+  cabinet: Government,
+  allCabinets: readonly Government[],
+): string => {
+  const bgSurname = lastToken(cabinet.pmBg);
+  const siblings = allCabinets
+    .filter((g) => lastToken(g.pmBg) === bgSurname)
+    .sort((a, b) => a.startDate.localeCompare(b.startDate));
+  if (siblings.length <= 1) return "";
+  const idx = siblings.findIndex((g) => g.id === cabinet.id);
+  if (idx < 0) return "";
+  return toRoman(idx + 1);
+};
+
+/** Localized surname + optional Roman numeral. Used in the header anchor
+ *  pill, KpiTile footer ("При [Surname N]: ..."), and the inline label on
+ *  each CabinetStrip pill. */
+export const cabinetShortLabel = (
+  cabinet: Government,
+  allCabinets: readonly Government[],
+  lang: "bg" | "en",
+): string => {
+  const surname = lastToken(lang === "bg" ? cabinet.pmBg : cabinet.pmEn);
+  const numeral = cabinetOrdinalNumeral(cabinet, allCabinets);
+  return numeral ? `${surname} ${numeral}` : surname;
+};
+
+/** Localized full PM name + optional Roman numeral. Used in section
+ *  headings, hero card titles, breadcrumbs, and table rows where the
+ *  three-name form is the visual primary. */
+export const cabinetFullLabel = (
+  cabinet: Government,
+  allCabinets: readonly Government[],
+  lang: "bg" | "en",
+): string => {
+  const fullName = lang === "bg" ? cabinet.pmBg : cabinet.pmEn;
+  const numeral = cabinetOrdinalNumeral(cabinet, allCabinets);
+  return numeral ? `${fullName} ${numeral}` : fullName;
+};

--- a/src/layout/header/CabinetAnchorPill.tsx
+++ b/src/layout/header/CabinetAnchorPill.tsx
@@ -17,6 +17,8 @@ import {
   useCabinetAnchor,
   useSetCabinetAnchor,
 } from "@/data/macro/cabinetAnchorContext";
+import { useGovernments } from "@/data/governments/useGovernments";
+import { cabinetShortLabel } from "@/data/governments/cabinetLabel";
 import { useCanonicalParties } from "@/data/parties/useCanonicalParties";
 import { colorForGovernmentSolid } from "@/screens/components/governments/governmentColors";
 import { Tooltip as UxTooltip } from "@/ux/Tooltip";
@@ -28,11 +30,18 @@ export const CabinetAnchorPill: FC = () => {
   const setAnchor = useSetCabinetAnchor();
   const navigate = useNavigate();
   const { colorFor } = useCanonicalParties();
+  const { data: governments } = useGovernments();
 
   if (!anchor) return null;
 
   const g = anchor.cabinet;
-  const surname = (lang === "bg" ? g.pmBg : g.pmEn).split(" ").pop() ?? "";
+  // Use disambiguated short label ("Борисов III") when the same PM has
+  // multiple cabinets; plain surname otherwise. governments is undefined
+  // briefly on first render before the React Query cache resolves —
+  // fall back to plain surname so the pill renders something readable.
+  const surname = governments
+    ? cabinetShortLabel(g, governments, lang)
+    : ((lang === "bg" ? g.pmBg : g.pmEn).split(" ").pop() ?? "");
   const color = colorForGovernmentSolid(g, colorFor);
   const labelPrefix = t("cabinet_anchor_pill_label");
   const tooltipText = t("cabinet_anchor_pill_tooltip");
@@ -64,7 +73,7 @@ export const CabinetAnchorPill: FC = () => {
           <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
             {labelPrefix}
           </span>
-          <span className="truncate max-w-[10ch]">{surname}</span>
+          <span className="truncate max-w-[14ch]">{surname}</span>
         </button>
       </UxTooltip>
       <span aria-hidden className="w-px bg-amber-500/30" />

--- a/src/screens/GovernmentDetailScreen.tsx
+++ b/src/screens/GovernmentDetailScreen.tsx
@@ -20,6 +20,7 @@ import {
   useGovernments,
   type Government,
 } from "@/data/governments/useGovernments";
+import { cabinetFullLabel } from "@/data/governments/cabinetLabel";
 import { useMacro } from "@/data/macro/useMacro";
 import { useCanonicalParties } from "@/data/parties/useCanonicalParties";
 import { useMps } from "@/data/parliament/useMps";
@@ -67,10 +68,11 @@ const termDomain = (g: Government): [number, number] => {
   return [Math.max(2005, start - pad), end + pad];
 };
 
-const Breadcrumb: FC<{ government: Government; lang: "bg" | "en" }> = ({
-  government,
-  lang,
-}) => {
+const Breadcrumb: FC<{
+  government: Government;
+  allGovernments: Government[];
+  lang: "bg" | "en";
+}> = ({ government, allGovernments, lang }) => {
   const { t } = useTranslation();
   return (
     <nav
@@ -82,22 +84,23 @@ const Breadcrumb: FC<{ government: Government; lang: "bg" | "en" }> = ({
       </Link>
       <ChevronRight className="h-3 w-3 opacity-60" aria-hidden />
       <span className="text-foreground truncate">
-        {lang === "bg" ? government.pmBg : government.pmEn}
+        {cabinetFullLabel(government, allGovernments, lang)}
       </span>
     </nav>
   );
 };
 
-const Hero: FC<{ government: Government; lang: "bg" | "en" }> = ({
-  government: g,
-  lang,
-}) => {
+const Hero: FC<{
+  government: Government;
+  allGovernments: Government[];
+  lang: "bg" | "en";
+}> = ({ government: g, allGovernments, lang }) => {
   const { t } = useTranslation();
   const { colorFor } = useCanonicalParties();
   const { findMpByName } = useMps();
   const ribbon = colorForGovernmentSolid(g, colorFor);
   const mp = findMpByName(g.pmBg);
-  const fullName = lang === "bg" ? g.pmBg : g.pmEn;
+  const fullName = cabinetFullLabel(g, allGovernments, lang);
   const parties = lang === "bg" ? g.parties : (g.partiesEn ?? g.parties);
   const tenure = `${formatDateLong(g.startDate, lang)} – ${formatDateLong(
     g.endDate,
@@ -260,11 +263,15 @@ export const GovernmentDetailScreen: FC = () => {
     );
   }
 
-  const fullName = lang === "bg" ? government.pmBg : government.pmEn;
+  const fullName = cabinetFullLabel(government, governments, lang);
 
   return (
     <div className="pb-12">
-      <Breadcrumb government={government} lang={lang} />
+      <Breadcrumb
+        government={government}
+        allGovernments={governments}
+        lang={lang}
+      />
 
       {fullXDomain ? (
         <section className="mb-4">
@@ -289,7 +296,7 @@ export const GovernmentDetailScreen: FC = () => {
         {t("cabinet_detail_title", { name: fullName })}
       </Title>
 
-      <Hero government={government} lang={lang} />
+      <Hero government={government} allGovernments={governments} lang={lang} />
 
       <section className="mb-8">
         <h2 className="text-lg font-semibold mb-1">

--- a/src/screens/components/governments/GovernmentTable.tsx
+++ b/src/screens/components/governments/GovernmentTable.tsx
@@ -6,6 +6,7 @@ import {
   Government,
   GovernmentEndReason,
 } from "@/data/governments/useGovernments";
+import { cabinetFullLabel } from "@/data/governments/cabinetLabel";
 import { MacroPayload, MacroPoint } from "@/data/macro/useMacro";
 import { useMps } from "@/data/parliament/useMps";
 import { useCanonicalParties } from "@/data/parties/useCanonicalParties";
@@ -309,7 +310,7 @@ export const GovernmentTable: FC<{
         </thead>
         <tbody>
           {sortedRows.map(({ g, indicators }) => {
-            const pm = lang === "bg" ? g.pmBg : g.pmEn;
+            const pm = cabinetFullLabel(g, governments, lang as "bg" | "en");
             const parties =
               lang === "bg" ? g.parties : (g.partiesEn ?? g.parties);
             const endReason =

--- a/src/screens/components/governments/GovernmentTimeline.tsx
+++ b/src/screens/components/governments/GovernmentTimeline.tsx
@@ -22,6 +22,10 @@ import {
   pointToFractionalX,
 } from "@/data/macro/useMacro";
 import { cabinetMetricsFor } from "@/data/macro/kpiSelectors";
+import {
+  cabinetFullLabel,
+  cabinetShortLabel,
+} from "@/data/governments/cabinetLabel";
 import type {
   PeerGeo,
   PeerIndicatorBlock,
@@ -396,8 +400,9 @@ const formatDateLocal = (iso: string | null, lang: "en" | "bg"): string => {
 
 const PillTooltip: FC<{
   g: Government;
+  allGovernments: Government[];
   lang: "en" | "bg";
-}> = ({ g, lang }) => {
+}> = ({ g, allGovernments, lang }) => {
   const { t } = useTranslation();
   const { findMpByName } = useMps();
   const endReasonMap: Record<GovernmentEndReason, string> = {
@@ -409,7 +414,7 @@ const PillTooltip: FC<{
     rotation_failed: t("gov_end_rotation_failed"),
     incumbent: t("gov_end_incumbent"),
   };
-  const fullName = lang === "bg" ? g.pmBg : g.pmEn;
+  const fullName = cabinetFullLabel(g, allGovernments, lang);
   const parties = lang === "bg" ? g.parties : (g.partiesEn ?? g.parties);
   const endReasonText = lang === "bg" ? g.endReasonBg : g.endReasonEn;
   const mp = findMpByName(g.pmBg);
@@ -552,8 +557,7 @@ export const CabinetStrip: FC<{
       <div className="overflow-x-auto pb-1">
         <div className="flex mb-1 rounded overflow-hidden h-24 w-max">
           {governments.map((g, i) => {
-            const surname =
-              (lang === "bg" ? g.pmBg : g.pmEn).split(" ").pop() ?? "";
+            const surname = cabinetShortLabel(g, governments, lang);
             const widthPx = pillWidthsPx[i];
             const horizontal = widthPx >= MOBILE_SCROLL_HORIZONTAL_PX;
             const isSelected = selectable && selectedSet.has(g.id);
@@ -563,7 +567,9 @@ export const CabinetStrip: FC<{
             return (
               <UxTooltip
                 key={`pill-${g.id}`}
-                content={<PillTooltip g={g} lang={lang} />}
+                content={
+                  <PillTooltip g={g} allGovernments={governments} lang={lang} />
+                }
               >
                 <div
                   role={selectable ? "button" : undefined}
@@ -655,8 +661,7 @@ export const CabinetStrip: FC<{
         const start = toFractionalYear(g.startDate);
         const end = toFractionalYear(g.endDate ?? new Date().toISOString());
         const widthPct = ((end - start) / (xDomain[1] - xDomain[0])) * 100;
-        const surname =
-          (lang === "bg" ? g.pmBg : g.pmEn).split(" ").pop() ?? "";
+        const surname = cabinetShortLabel(g, governments, lang);
         const horizontal = widthPct >= horizontalThreshold;
         const showLabel = widthPct >= labelThreshold;
         const isSelected = selectable && selectedSet.has(g.id);
@@ -666,7 +671,9 @@ export const CabinetStrip: FC<{
         return (
           <UxTooltip
             key={`pill-${g.id}`}
-            content={<PillTooltip g={g} lang={lang} />}
+            content={
+              <PillTooltip g={g} allGovernments={governments} lang={lang} />
+            }
           >
             <div
               role={selectable ? "button" : undefined}

--- a/src/screens/components/governments/SelectedCabinetCallout.tsx
+++ b/src/screens/components/governments/SelectedCabinetCallout.tsx
@@ -15,9 +15,11 @@ import { Link } from "react-router-dom";
 import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import {
+  useGovernments,
   type Government,
   type GovernmentEndReason,
 } from "@/data/governments/useGovernments";
+import { cabinetFullLabel } from "@/data/governments/cabinetLabel";
 import { useCanonicalParties } from "@/data/parties/useCanonicalParties";
 import { useMps } from "@/data/parliament/useMps";
 import { MpAvatar } from "@/screens/components/candidates/MpAvatar";
@@ -45,10 +47,18 @@ export const SelectedCabinetCallout: FC<{
   const { t } = useTranslation();
   const { colorFor } = useCanonicalParties();
   const { findMpByName } = useMps();
+  const { data: allGovernments } = useGovernments();
   const ribbon = colorForGovernmentSolid(g, colorFor);
   const mp = findMpByName(g.pmBg);
 
-  const fullName = lang === "bg" ? g.pmBg : g.pmEn;
+  // Disambiguated full label: appends " III" / " II" when the same PM has
+  // multiple cabinets. Falls back to plain full name while governments is
+  // loading.
+  const fullName = allGovernments
+    ? cabinetFullLabel(g, allGovernments, lang)
+    : lang === "bg"
+      ? g.pmBg
+      : g.pmEn;
   const parties = lang === "bg" ? g.parties : (g.partiesEn ?? g.parties);
   const tenure = `${formatDateShort(g.startDate, lang)} – ${formatDateShort(
     g.endDate,

--- a/src/screens/components/macro/CabinetScoreCard.tsx
+++ b/src/screens/components/macro/CabinetScoreCard.tsx
@@ -11,7 +11,11 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { ArrowUpRight } from "lucide-react";
 import { useCanonicalParties } from "@/data/parties/useCanonicalParties";
-import type { Government } from "@/data/governments/useGovernments";
+import {
+  useGovernments,
+  type Government,
+} from "@/data/governments/useGovernments";
+import { cabinetFullLabel } from "@/data/governments/cabinetLabel";
 import type { MacroPayload } from "@/data/macro/useMacro";
 import {
   cabinetMetricsFor,
@@ -91,12 +95,17 @@ export const CabinetScoreDetail: FC<{
   const { t, i18n } = useTranslation();
   const lang: "bg" | "en" = i18n.language === "bg" ? "bg" : "en";
   const { colorFor } = useCanonicalParties();
+  const { data: allGovernments } = useGovernments();
   const metrics: CabinetMetrics = useMemo(
     () => cabinetMetricsFor(g, macro),
     [g, macro],
   );
 
-  const fullName = lang === "bg" ? g.pmBg : g.pmEn;
+  const fullName = allGovernments
+    ? cabinetFullLabel(g, allGovernments, lang)
+    : lang === "bg"
+      ? g.pmBg
+      : g.pmEn;
   const parties = lang === "bg" ? g.parties : (g.partiesEn ?? g.parties);
   const tenure = `${formatDateShort(g.startDate, lang)} – ${formatDateShort(g.endDate, lang)}`;
   const ribbon = colorForGovernmentSolid(g, colorFor);

--- a/src/screens/components/macro/KpiTile.tsx
+++ b/src/screens/components/macro/KpiTile.tsx
@@ -16,6 +16,7 @@ import { Link, useNavigate } from "react-router-dom";
 import { ArrowUpRight } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useGovernments } from "@/data/governments/useGovernments";
+import { cabinetShortLabel } from "@/data/governments/cabinetLabel";
 import { useMacro, type MacroIndicatorKey } from "@/data/macro/useMacro";
 import { useMacroPeers } from "@/data/macro/useMacroPeers";
 import {
@@ -158,10 +159,14 @@ export const KpiTile: FC<Props> = ({ indicatorKey, className }) => {
         : `${delta >= 0 ? "+" : ""}${delta.toFixed(
             entry.deltaDecimals ?? 1,
           )}${entry.deltaSuffix}`;
-    const surname =
-      (lang === "bg" ? anchor.cabinet.pmBg : anchor.cabinet.pmEn)
-        .split(" ")
-        .pop() ?? "";
+    // Disambiguated short label ("Борисов III") so the same Borisov
+    // doesn't appear three times across tiles anchored to different
+    // cabinets with identical footer captions.
+    const surname = governments
+      ? cabinetShortLabel(anchor.cabinet, governments, lang)
+      : ((lang === "bg" ? anchor.cabinet.pmBg : anchor.cabinet.pmEn)
+          .split(" ")
+          .pop() ?? "");
     const detailHref = `/governments/${encodeURIComponent(anchor.cabinet.id)}#kpi-${indicatorKey}`;
     return (
       <button

--- a/src/screens/indicators/IndicatorsCompareScreen.tsx
+++ b/src/screens/indicators/IndicatorsCompareScreen.tsx
@@ -27,6 +27,7 @@ import { useTranslation } from "react-i18next";
 import { Link } from "react-router-dom";
 import { ArrowLeft, ChevronRight } from "lucide-react";
 import { useGovernments } from "@/data/governments/useGovernments";
+import { cabinetFullLabel } from "@/data/governments/cabinetLabel";
 import {
   useCabinetAnchor,
   useSetCabinetAnchor,
@@ -93,14 +94,14 @@ export const IndicatorsCompareScreen: FC = () => {
       <Link to="/indicators" className="hover:text-foreground hover:underline">
         {t("eu_compare_breadcrumb_bg")}
       </Link>
-      {selectedCabinet ? (
+      {selectedCabinet && governments ? (
         <>
           <ChevronRight className="h-3 w-3 opacity-60" aria-hidden />
           <Link
             to={`/governments/${encodeURIComponent(selectedCabinet.id)}`}
             className="hover:text-foreground hover:underline"
           >
-            {lang === "bg" ? selectedCabinet.pmBg : selectedCabinet.pmEn}
+            {cabinetFullLabel(selectedCabinet, governments, lang)}
           </Link>
         </>
       ) : null}
@@ -219,7 +220,7 @@ export const IndicatorsCompareScreen: FC = () => {
         <EuCompareSourcesStrip />
       </section>
 
-      {selectedCabinet ? (
+      {selectedCabinet && governments ? (
         <div className="mt-6 flex flex-wrap justify-end">
           <Link
             to={`/governments/${encodeURIComponent(selectedCabinet.id)}`}
@@ -227,7 +228,7 @@ export const IndicatorsCompareScreen: FC = () => {
           >
             <ArrowLeft className="h-3 w-3" />
             {t("eu_compare_back_to_cabinet", {
-              name: lang === "bg" ? selectedCabinet.pmBg : selectedCabinet.pmEn,
+              name: cabinetFullLabel(selectedCabinet, governments, lang),
             })}
           </Link>
         </div>


### PR DESCRIPTION
## Problem

'СПРЯМО Борисов' in the header pill was ambiguous — three distinct Borisov cabinets share that surname (also Yanev I/II and Glavchev I/II). The header anchor pill, KpiTile footer, and CabinetStrip pill labels all collapsed to the plain surname.

## Fix

Convention: append the Roman numeral in chronological order (matches BG media + Wikipedia). Singletons (Stanishev, Petkov, Denkov, etc.) get no numeral.

New helpers in `src/data/governments/cabinetLabel.ts`:
- `cabinetOrdinalNumeral(c, all)` → 'I' | 'II' | … | '' for singletons
- `cabinetShortLabel(c, all, lang)` → 'Борисов III' (surname + numeral)
- `cabinetFullLabel(c, all, lang)` → 'Бойко Методиев Борисов III'

### Applied at every cabinet-name surface

**Surname-only (`cabinetShortLabel`):**
- CabinetAnchorPill — header now shows 'СПРЯМО Борисов III'
- KpiTile anchor-aware footer — 'При Борисов III: X → Y'
- CabinetStrip pill inline labels — 'Борисов I', 'Борисов II', 'Борисов III'

**Full-name (`cabinetFullLabel`):**
- GovernmentDetailScreen Hero + Title + Breadcrumb
- IndicatorsCompareScreen breadcrumb + back-to-cabinet link
- SelectedCabinetCallout heading
- CabinetScoreDetail card heading
- GovernmentTable row PM cell
- PillTooltip (hover on strip pill)

**Prerender (SEO):**
- Per-cabinet /governments/<slug> SEO titles, descriptions, and body HTML use the disambiguated label so indexable copy matches the in-app rendering. Standalone numeral helper mirrors the runtime one (the script is a build-time tsx pass with no React dependency).

### Implementation detail
- Disambiguation key: BG surname (last token of pmBg) — stable across the language toggle
- Order: ascending `startDate`, so chronology maps to the numeral correctly even if slugs are renamed
- Bumped CabinetAnchorPill max-width from 10ch to 14ch so 'Борисов III' (11 chars) doesn't get truncated

## Test plan
- [ ] /indicators?cabinet=borisov-1 → header pill 'СПРЯМО Борисов I', KpiTile footers 'При Борисов I: …'
- [ ] /indicators?cabinet=borisov-2 → all instances become 'Борисов II'
- [ ] /indicators?cabinet=borisov-3 → 'Борисов III'
- [ ] Strip pills show I/II/III for Borisov, I/II for Yanev and Glavchev; singletons unchanged
- [ ] /governments/borisov-2 → page heading 'Бойко Методиев Борисов II'
- [ ] /indicators/compare?cabinet=denkov (singleton) → no numeral appended