### PR TITLE
ux(chart-events): tighten gap between chart and events strip

### DIFF
--- a/src/screens/components/governments/GovernmentTimeline.tsx
+++ b/src/screens/components/governments/GovernmentTimeline.tsx
@@ -1015,7 +1015,13 @@ export const GovernmentTimeline: FC<{
               top: 8,
               right: insets.marginRight,
               left: insets.marginLeft,
-              bottom: 24,
+              // Tight bottom margin — x-axis label height (~14px at fontSize
+              // 11) + a 4px breathing strip. The rotated event-marker labels
+              // render inside the chart's plot area, not in this margin, so
+              // we don't need to leave room for them here. ChartEventsStrip
+              // then sits flush against the year labels (via negative top
+              // margin on the strip) for a compact composition.
+              bottom: 18,
             }}
           >
             <CartesianGrid
@@ -1263,10 +1269,14 @@ export const GovernmentTimeline: FC<{
         </ResponsiveContainer>
       </div>
       {chartEvents && chartEvents.length > 0 ? (
+        // Negative top margin pulls the strip up into the chart's bottom
+        // margin so the event lanes sit immediately below the year axis
+        // labels — earlier mt-1 left a visible ~30px gap that read as
+        // "the strip is unrelated to the chart above".
         <ChartEventsStrip
           events={chartEvents}
           xDomain={xDomain}
-          className="mt-1"
+          className="-mt-2"
         />
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
The events strip was sitting ~30–40px below the year labels, reading as a separate visual block rather than an annotation on the chart above.

## Changes
- `LineChart` bottom margin **24 → 18** — x-axis labels (fontSize 11) need ~14px; 18 leaves a 4px breathing strip without reserving dead space
- `ChartEventsStrip` wrapper **`mt-1` → `-mt-2`** — pulls the strip up into the chart's remaining bottom margin so the event lanes sit immediately below the year labels

Net: ~12px tighter. The rotated EU-milestone labels at the bottom of the chart still fit (they render inside the plot viewBox, not the margin).

## Test plan
- [ ] /governments → events lanes sit visually adjacent to the year labels, not in a separate block
- [ ] /governments/zhelyazkov → no clipping of x-axis years (2024, 2025, 2026) or EU milestone labels
- [ ] /indicators → expand hero chart → same compact spacing applies