### PR TITLE
local: guard colorFor() result so Dot color is always a string

### DIFF
--- a/src/screens/dashboard/local/LocalMunicipalityExtras.tsx
+++ b/src/screens/dashboard/local/LocalMunicipalityExtras.tsx
@@ -61,12 +61,14 @@ export const MayorVsCouncilTile: FC<{ bundle: LocalMunicipalityBundle }> = ({
     leadingCouncil.localPartyName,
   );
   const aligned = mayorPid === councilPid;
-  const mayorColor = mayor.primaryCanonicalId
-    ? colorFor(mayor.primaryCanonicalId)
-    : "#9CA3AF";
-  const councilColor = leadingCouncil.primaryCanonicalId
-    ? colorFor(leadingCouncil.primaryCanonicalId)
-    : "#9CA3AF";
+  const mayorColor =
+    (mayor.primaryCanonicalId
+      ? colorFor(mayor.primaryCanonicalId)
+      : "#9CA3AF") ?? "#9CA3AF";
+  const councilColor =
+    (leadingCouncil.primaryCanonicalId
+      ? colorFor(leadingCouncil.primaryCanonicalId)
+      : "#9CA3AF") ?? "#9CA3AF";
   return (
     <StatCard
       label={
@@ -116,9 +118,10 @@ export const TopCouncillorsTile: FC<{ bundle: LocalMunicipalityBundle }> = ({
           prefVotes: c.prefVotes,
           prefPct: c.prefPct,
           partyName: p.localPartyName,
-          color: p.primaryCanonicalId
-            ? colorFor(p.primaryCanonicalId)
-            : "#9CA3AF",
+          color:
+            (p.primaryCanonicalId
+              ? colorFor(p.primaryCanonicalId)
+              : "#9CA3AF") ?? "#9CA3AF",
         })),
     );
     return all.sort((a, b) => b.prefVotes - a.prefVotes).slice(0, 8);


### PR DESCRIPTION
## Why

`origin/main` (`6970f316e`) is red in CI — the `lint + build + playwright` job fails at `tsc -b` with exit code 2:

```
src/screens/dashboard/local/LocalMunicipalityExtras.tsx:89  Type 'string | undefined' is not assignable to type 'string'.
src/screens/dashboard/local/LocalMunicipalityExtras.tsx:96  Type 'string | undefined' is not assignable to type 'string'.
src/screens/dashboard/local/LocalMunicipalityExtras.tsx:149 Type 'string | undefined' is not assignable to type 'string'.
```

`colorFor()` returns `string | undefined`, so `mayorColor`, `councilColor`, and the per-row `color` were typed `string | undefined`. `Dot`'s prop is `color: string`, so each `<Dot color={…} />` failed to type-check.

## Fix

Wrap each `primaryCanonicalId ? colorFor(...) : "#9CA3AF"` ternary in `(...) ?? "#9CA3AF"` so the grey fallback also covers an undefined palette lookup. One-file change; the result is always a `string`.

## Verification

- `tsc -b` → exit 0
- `eslint src/screens/dashboard/local/LocalMunicipalityExtras.tsx` → exit 0
